### PR TITLE
upgrade browserify and cheerio, add basedir option, support for src attr

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,9 @@
     "start": "node test.js"
   },
   "dependencies": {
-    "through": "~2.3.4",
-    "cheerio": "~0.12.0",
-    "browserify": "~2.18.1"
+    "browserify": "^4.1.9",
+    "cheerio": "cheeriojs/cheerio",
+    "through": "~2.3.4"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
i'm using this in https://github.com/maxogden/packify

this will use the script `src` property if it exists, otherwise it will fall back to the previous method of using the script tag text
